### PR TITLE
Fixing typo in introductory vignette

### DIFF
--- a/vignettes/vitals.Rmd
+++ b/vignettes/vitals.Rmd
@@ -186,7 +186,7 @@ are_task_data |>
   geom_bar()
 ```
 
-Claude answered fully correctly in `r sum(are_task_data$score == "C")` out of `r nrow(are_task_data)` samples, and partially correctly `r sum(are_task_data$score == "P")` times.For me, this leads to all sorts of questions:
+Claude answered fully correctly in `r sum(are_task_data$score == "C")` out of `r nrow(are_task_data)` samples, and partially correctly `r sum(are_task_data$score == "P")` times. For me, this leads to all sorts of questions:
 
 * Are there any models that are cheaper than Claude that would do just as well? Or even a local model?
 * Are there other models available that would do better out of the box?

--- a/vignettes/writing-evals.Rmd
+++ b/vignettes/writing-evals.Rmd
@@ -67,7 +67,7 @@ Scorers take the `input`, `target`, and the solver's output, and deliver some ju
 
 When implementing a scorer, you have a few options
 
--   Deterministic scoring: In some specific situations, it's possible to write code that can check correctness without any use of an LLM. For example, if your solver chooses an answer from multiple choices, you could just use a regular expression (as in the scorers `detect_match()` and friends). Or, if your scorer outputs code, you could check if it compiles/parses and then run that code through a unit test.
+-   Deterministic scoring: In some specific situations, it's possible to write code that can check correctness without any use of an LLM. For example, if your solver chooses an answer from multiple choices, you could just use a regular expression (as in the scorers `detect_match()` and friends). Or, if your solver outputs code, you could check if it compiles/parses and then run that code through a unit test.
 -   LLM-as-a-judge: In most situations, you'll want to pass the input, the solver's result, and the grading guidance (`target`) to a model, and ask the model to assign some score. (vitals natively supports factors with levels `I < P < C`, standing for Incorrect, (optional) Partially Correct, and Correct.)
 -   Human grading: In the earliest (before you even develop a scorer) and latest (right before your product goes to production) stages of product development, you should be spending a lot of time looking at the solver's outputs yourself.
 

--- a/vignettes/writing-evals.Rmd
+++ b/vignettes/writing-evals.Rmd
@@ -67,7 +67,7 @@ Scorers take the `input`, `target`, and the solver's output, and deliver some ju
 
 When implementing a scorer, you have a few options
 
--   Deterministic scoring: In some specific situations, it's possible to write code that can check correctness without any use of an LLM. For example, if your solver chooses an answer from multiple choices, you could just use a regular expression (as in the scorers `detect_match()` and friends). Or, if your solver outputs code, you could check if it compiles/parses and then run that code through a unit test.
+-   Deterministic scoring: In some specific situations, it's possible to write code that can check correctness without any use of an LLM. For example, if your solver chooses an answer from multiple choices, you could just use a regular expression (as in the scorers `detect_match()` and friends). Or, if your scorer outputs code, you could check if it compiles/parses and then run that code through a unit test.
 -   LLM-as-a-judge: In most situations, you'll want to pass the input, the solver's result, and the grading guidance (`target`) to a model, and ask the model to assign some score. (vitals natively supports factors with levels `I < P < C`, standing for Incorrect, (optional) Partially Correct, and Correct.)
 -   Human grading: In the earliest (before you even develop a scorer) and latest (right before your product goes to production) stages of product development, you should be spending a lot of time looking at the solver's outputs yourself.
 


### PR DESCRIPTION
Changed "times.For" to "times. For". Fixes #150