### PR TITLE
updating default $log dir

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # vitals (development version)
 
+* `$eval()` and `$log()` will now write log files to the same default 
+  directory--the one specified when initializing the Task object. 
+  Previously, `$eval()` wrote to that directory, while `$log()` wrote 
+  to `vitals_log_dir()` (#158 by @SokolovAnatoliy).
+
 * Solvers and scorers can now return arbitrary R objects in metadata; they 
   will be summarized in a lossy format when logged to .json.
 

--- a/R/task.R
+++ b/R/task.R
@@ -332,7 +332,7 @@ Task <- R6::R6Class(
     #' @param dir The directory to write the log to.
     #'
     #' @return The path to the logged file, invisibly.
-    log = function(dir = vitals_log_dir()) {
+    log = function(dir = self$dir) {
       if (!private$scored) {
         cli::cli_abort(
           "Task has not been scored yet. Run task$score() first."
@@ -401,15 +401,10 @@ Task <- R6::R6Class(
       )
 
       if (is.na(dir)) {
-        if (!is.na(self$dir)) {
-          dir <- self$dir
-        } else {
-          dir <- tempdir()
-        }
+        self$dir <- tempdir()
       }
 
-      self$dir <- dir
-      log_path <- eval_log_write(eval_log, dir = dir)
+      log_path <- eval_log_write(eval_log, dir = self$dir)
 
       invisible(log_path)
     },

--- a/man/Task.Rd
+++ b/man/Task.Rd
@@ -302,7 +302,7 @@ Log the task to a directory.
 Note that, if an \code{VITALS_LOG_DIR} envvar is set, this will happen
 automatically in \verb{$eval()}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Task$log(dir = vitals_log_dir())}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Task$log(dir = self$dir)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{


### PR DESCRIPTION
Updating $log to use path provided at $new instead of defaulting to vitals_log_dir(). Fixes #144