### PR TITLE
Improve log validation error formatting with CLI styling

### DIFF
--- a/tests/testthat/helper-valid_log.R
+++ b/tests/testthat/helper-valid_log.R
@@ -68,27 +68,34 @@ expect_valid_log <- local({
       stderr = TRUE
     )
 
-    # Get rid of elements starting with "For further information visit"
-    result <- result[!grepl("For further information visit", result)]
-    # Add .field CLI on the fields
-    result_length <- length(result)
-    field_positions <- seq(2, result_length, by = 2)
+    # "inst/test/inspect/logs/2025-03-24T10-39-36-05-00_simple-arithmetic_fQ9mYnqZFhtEuUenPpJgKL.json"
+    if (length(result) == 1) {
+      formatted_message <- cli::format_message(c(
+        "The generated log did not pass the pydantic model:",
+        glue::glue("{{.field {result[1]}}}")
+      ))
+    } else {
+      # Get rid of elements starting with "For further information visit"
+      result <- result[!grepl("For further information visit", result)]
+      # Add .field CLI on the fields
+      result_length <- length(result)
+      field_positions <- seq(2, result_length, by = 2)
 
-    for (pos in field_positions) {
-      result[pos] <- glue::glue("{{.field {result[pos]}}}")
+      for (pos in field_positions) {
+        result[pos] <- glue::glue("{{.field {result[pos]}}}")
+      }
+
+      result_with_breaks <- result[1] # Start with first element
+      for (i in seq(2, length(result), by = 2)) {
+        result_with_breaks <- c(result_with_breaks, "", result[i:(i + 1)])
+      }
+
+      formatted_message <- cli::format_message(c(
+        "The generated log did not pass the pydantic model:",
+        "",
+        result_with_breaks
+      ))
     }
-
-    result_with_breaks <- result[1] # Start with first element
-    for (i in seq(2, length(result), by = 2)) {
-      result_with_breaks <- c(result_with_breaks, "", result[i:(i + 1)])
-    }
-
-    formatted_message <- cli::format_message(c(
-      "The generated log did not pass the pydantic model:",
-      "",
-      result_with_breaks
-    ))
-
     status <- attr(result, "status")
 
     expect(

--- a/tests/testthat/helper-valid_log.R
+++ b/tests/testthat/helper-valid_log.R
@@ -67,14 +67,33 @@ expect_valid_log <- local({
       stdout = TRUE,
       stderr = TRUE
     )
+
+    # Get rid of elements starting with "For further information visit"
+    result <- result[!grepl("For further information visit", result)]
+    # Add .field CLI on the fields
+    result_length <- length(result)
+    field_positions <- seq(2, result_length, by = 2)
+
+    for (pos in field_positions) {
+      result[pos] <- glue::glue("{{.field {result[pos]}}}")
+    }
+
+    result_with_breaks <- result[1] # Start with first element
+    for (i in seq(2, length(result), by = 2)) {
+      result_with_breaks <- c(result_with_breaks, "", result[i:(i + 1)])
+    }
+
+    formatted_message <- cli::format_message(c(
+      "The generated log did not pass the pydantic model:",
+      "",
+      result_with_breaks
+    ))
+
     status <- attr(result, "status")
 
     expect(
       is.null(status) || status == 0,
-      paste0(
-        c("The generated log did not pass the pydantic model: ", result),
-        collapse = "\n"
-      )
+      formatted_message
     )
   }
 })


### PR DESCRIPTION
Simon, I ended up using `cli::format_message()` to see cli-styled messages from `expect()`. One other change I've made since Tidy Dev Day is to account for single-line error messages (i.e. `Error: Expecting ',' delimiter: line 165 column 13 (char 3699`) with an `if else` statement.

Fixes #148