### PR TITLE
✨ Convert numeric solver results to character strings in logs

### DIFF
--- a/R/translate.R
+++ b/R/translate.R
@@ -205,7 +205,7 @@ translate_to_score <- function(
   if (is.null(scorer_chat)) {
     return(list(
       value = score,
-      answer = output,
+      answer = as.character(output),
       explanation = scorer,
       metadata = metadata
     ))
@@ -216,7 +216,7 @@ translate_to_score <- function(
 
   list(
     value = score,
-    answer = output,
+    answer = as.character(output),
     explanation = explanation,
     metadata = c(
       list(

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -144,6 +144,41 @@ test_that("vitals writes valid eval logs (solver errors on tool call, claude)", 
   expect_valid_log(log_file[1])
 })
 
+test_that("vitals writes valid logs with numeric solver results (#145)", {
+  skip_if(identical(Sys.getenv("ANTHROPIC_API_KEY"), ""))
+  tmp_dir <- withr::local_tempdir()
+  withr::local_envvar(list(VITALS_LOG_DIR = tmp_dir))
+  withr::local_options(cli.default_handler = function(...) {})
+  local_mocked_bindings(interactive = function(...) FALSE)
+
+  simple_dataset <- tibble::tibble(
+    input = c("What's 2+2?", "What's 2+3?"),
+    target = c("4", "5")
+  )
+
+  chat <- ellmer::chat_anthropic(model = "claude-3-7-sonnet-latest")
+  chat$chat("Hey!")
+
+  simple_solver <- function(inputs) {
+    list(
+      result = rep(1.5, length(inputs)),
+      solver_chat = lapply(inputs, function(x) {
+        chat
+      })
+    )
+  }
+
+  tsk <- Task$new(
+    dataset = simple_dataset,
+    solver = simple_solver,
+    scorer = model_graded_qa()
+  )
+
+  tsk$eval()
+  log_path <- tsk$log()
+  expect_valid_log(log_path)
+})
+
 test_that("as_metadata can make lists into a named vector (#69)", {
   res <- as_metadata(mtcars[1:2, 1:2])
   expect_type(res, "list")


### PR DESCRIPTION
Fixes #145

Converts numeric solver results to character strings before logging to ensure compatibility with Pydantic validation.

## Changes
- Modified `translate_to_score()` to use `as.character(output)` for the answer field
- Added test case for numeric solver results

Generated with [Claude Code](https://claude.ai/code)