### PR TITLE
route arguments to the solver and scorer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 * `$eval()` now routes arguments to solvers and scorers based on
   their function signatures, allowing users to pass arguments specific to each
-  without requiring ellipses in both functions (#98, #152). `$eval()` now errors when supplied unnamed arguments.
+  without requiring ellipses in both functions (#152). 
+  `$eval()` now errors when supplied unnamed arguments.
 
 * Solvers and scorers can now return arbitrary R objects in metadata; they
   will be summarized in a lossy format when logged to .json.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # vitals (development version)
 
-* Solvers and scorers can now return arbitrary R objects in metadata; they 
+* `$eval()` now routes arguments to solvers and scorers based on
+  their function signatures, allowing users to pass arguments specific to each
+  without requiring ellipses in both functions (#98, #152). `$eval()` now errors when supplied unnamed arguments.
+
+* Solvers and scorers can now return arbitrary R objects in metadata; they
   will be summarized in a lossy format when logged to .json.
 
 * The package will now set the envvar `IN_VITALS_EVAL` to `"true"` during 

--- a/R/task.R
+++ b/R/task.R
@@ -184,6 +184,12 @@ Task <- R6::R6Class(
     #' calling `$new()` and then this method on the resulting object.
     #'
     #' @param ... Additional arguments passed to the solver and scorer functions.
+    #' All arguments must be named. Arguments are routed based on function
+    #' signatures: if an argument name matches a parameter in the solver, it goes
+    #' to the solver; if it matches a parameter in the scorer, it goes to the
+    #' scorer. Arguments matching both go to both. Unmatched arguments are passed
+    #' to any function with `...` in its signature. An error is raised if an
+    #' argument matches neither function and neither accepts `...`.
     #' @param view Automatically open the viewer after evaluation (defaults to
     #' TRUE if interactive, FALSE otherwise).
     #'
@@ -195,11 +201,21 @@ Task <- R6::R6Class(
         private$reset_for_new_eval()
       }
 
+      dots <- list(...)
+      if (length(dots) > 0 && (is.null(names(dots)) || any(names(dots) == ""))) {
+        cli::cli_abort(
+          "All arguments in {.code ...} must be named.",
+          call = call2("$eval()")
+        )
+      }
+
+      split_args <- private$split_dots(dots)
+
       cli::cli_progress_step("Solving")
-      self$solve(..., epochs = epochs)
+      do.call(self$solve, c(split_args$solver, list(epochs = epochs)))
 
       cli::cli_progress_step("Scoring")
-      self$score(...)
+      do.call(self$score, split_args$scorer)
       self$measure()
 
       self$log(self$dir)
@@ -764,6 +780,50 @@ Task <- R6::R6Class(
       }
 
       samples
+    },
+
+    split_dots = function(dots) {
+      solver_fn <- environment(private$solver)$fn
+      scorer_fn <- environment(private$scorer)$fn
+
+      solver_formals <- names(formals(solver_fn))
+      scorer_formals <- names(formals(scorer_fn))
+
+      solver_has_dots <- "..." %in% solver_formals
+      scorer_has_dots <- "..." %in% scorer_formals
+
+      solver_args <- list()
+      scorer_args <- list()
+
+      for (arg_name in names(dots)) {
+        matches_solver <- arg_name %in% solver_formals
+        matches_scorer <- arg_name %in% scorer_formals
+
+        if (matches_solver) {
+          solver_args[[arg_name]] <- dots[[arg_name]]
+        }
+
+        if (matches_scorer) {
+          scorer_args[[arg_name]] <- dots[[arg_name]]
+        }
+
+        if (!matches_solver && !matches_scorer) {
+          if (solver_has_dots) {
+            solver_args[[arg_name]] <- dots[[arg_name]]
+          }
+          if (scorer_has_dots) {
+            scorer_args[[arg_name]] <- dots[[arg_name]]
+          }
+          if (!solver_has_dots && !scorer_has_dots) {
+            cli::cli_abort(
+              "Argument {.arg {arg_name}} does not match any parameter in the solver or scorer functions.",
+              call = call2("$eval()")
+            )
+          }
+        }
+      }
+
+      list(solver = solver_args, scorer = scorer_args)
     },
 
     # The output of `logged(solver)(...)`

--- a/tests/testthat/_snaps/task.md
+++ b/tests/testthat/_snaps/task.md
@@ -111,3 +111,19 @@
       Error in `$score()`:
       ! Elements in the scorer_chat output from `scorer` must be ellmer Chat objects, not a string.
 
+# eval errors with unnamed arguments
+
+    Code
+      tsk$eval("unnamed_arg")
+    Condition
+      Error in `$eval()`:
+      ! All arguments in `...` must be named.
+
+# eval errors when argument matches neither function and neither has ellipses
+
+    Code
+      tsk$eval(unmatched_param = "error")
+    Condition
+      Error in `$eval()`:
+      ! Argument `unmatched_param` does not match any parameter in the solver or scorer functions.
+

--- a/tests/testthat/test-task.R
+++ b/tests/testthat/test-task.R
@@ -893,3 +893,187 @@ test_that("token usage is logged correctly (with unrelated token usage)", {
     usage_after_solve$output - usage_before$output
   )
 })
+
+# argument routing --------------------------------------------------------
+test_that("eval routes arguments correctly to solver and scorer", {
+  withr::local_envvar(list(VITALS_LOG_DIR = withr::local_tempdir()))
+  withr::local_options(cli.default_handler = function(...) {})
+  local_mocked_bindings(interactive = function(...) FALSE)
+  library(ellmer)
+
+  simple_addition <- tibble::tibble(
+    input = c("What's 2+2?", "What's 2+3?"),
+    target = c("4", "5")
+  )
+
+  solver_arg_tracker <- NULL
+  scorer_arg_tracker <- NULL
+
+  custom_solver <- function(inputs, solver_param = "default_solver") {
+    solver_arg_tracker <<- solver_param
+    list(
+      result = c("4", "5"),
+      solver_chat = list(
+        chat_openai(model = "gpt-4.1-nano"),
+        chat_openai(model = "gpt-4.1-nano")
+      )
+    )
+  }
+
+  custom_scorer <- function(samples, scorer_param = "default_scorer") {
+    scorer_arg_tracker <<- scorer_param
+    list(score = c(1, 1))
+  }
+
+  tsk <- Task$new(
+    dataset = simple_addition,
+    solver = custom_solver,
+    scorer = custom_scorer
+  )
+
+  tsk$eval(solver_param = "passed_to_solver", scorer_param = "passed_to_scorer")
+
+  expect_equal(solver_arg_tracker, "passed_to_solver")
+  expect_equal(scorer_arg_tracker, "passed_to_scorer")
+})
+
+test_that("eval routes arguments to functions with ellipses", {
+  withr::local_envvar(list(VITALS_LOG_DIR = withr::local_tempdir()))
+  withr::local_options(cli.default_handler = function(...) {})
+  local_mocked_bindings(interactive = function(...) FALSE)
+  library(ellmer)
+
+  simple_addition <- tibble::tibble(
+    input = c("What's 2+2?", "What's 2+3?"),
+    target = c("4", "5")
+  )
+
+  solver_dots_tracker <- NULL
+  scorer_dots_tracker <- NULL
+
+  solver_with_dots <- function(inputs, ...) {
+    dots <- list(...)
+    solver_dots_tracker <<- dots
+    list(
+      result = c("4", "5"),
+      solver_chat = list(
+        chat_openai(model = "gpt-4.1-nano"),
+        chat_openai(model = "gpt-4.1-nano")
+      )
+    )
+  }
+
+  scorer_with_dots <- function(samples, ...) {
+    dots <- list(...)
+    scorer_dots_tracker <<- dots
+    list(score = c(1, 1))
+  }
+
+  tsk <- Task$new(
+    dataset = simple_addition,
+    solver = solver_with_dots,
+    scorer = scorer_with_dots
+  )
+
+  tsk$eval(unmatched_param = "goes_to_both")
+
+  expect_equal(solver_dots_tracker$unmatched_param, "goes_to_both")
+  expect_equal(scorer_dots_tracker$unmatched_param, "goes_to_both")
+})
+
+test_that("eval routes unmatched arguments to solver with ellipses only", {
+  withr::local_envvar(list(VITALS_LOG_DIR = withr::local_tempdir()))
+  withr::local_options(cli.default_handler = function(...) {})
+  local_mocked_bindings(interactive = function(...) FALSE)
+  library(ellmer)
+
+  simple_addition <- tibble::tibble(
+    input = c("What's 2+2?", "What's 2+3?"),
+    target = c("4", "5")
+  )
+
+  solver_dots_tracker <- NULL
+
+  solver_with_dots <- function(inputs, ...) {
+    dots <- list(...)
+    solver_dots_tracker <<- dots
+    list(
+      result = c("4", "5"),
+      solver_chat = list(
+        chat_openai(model = "gpt-4.1-nano"),
+        chat_openai(model = "gpt-4.1-nano")
+      )
+    )
+  }
+
+  scorer_no_dots <- function(samples) {
+    list(score = c(1, 1))
+  }
+
+  tsk <- Task$new(
+    dataset = simple_addition,
+    solver = solver_with_dots,
+    scorer = scorer_no_dots
+  )
+
+  tsk$eval(unmatched_param = "goes_to_solver")
+
+  expect_equal(solver_dots_tracker$unmatched_param, "goes_to_solver")
+})
+
+test_that("eval errors with unnamed arguments", {
+  withr::local_envvar(list(VITALS_LOG_DIR = withr::local_tempdir()))
+  withr::local_options(cli.default_handler = function(...) {})
+  local_mocked_bindings(interactive = function(...) FALSE)
+
+  simple_addition <- tibble::tibble(
+    input = c("What's 2+2?", "What's 2+3?"),
+    target = c("4", "5")
+  )
+
+  tsk <- Task$new(
+    dataset = simple_addition,
+    solver = function(inputs) {
+      list(result = c("4", "5"), solver_chat = list(NULL, NULL))
+    },
+    scorer = function(samples) {
+      list(score = c(1, 1))
+    }
+  )
+
+  expect_snapshot(tsk$eval("unnamed_arg"), error = TRUE)
+})
+
+test_that("eval errors when argument matches neither function and neither has ellipses", {
+  withr::local_envvar(list(VITALS_LOG_DIR = withr::local_tempdir()))
+  withr::local_options(cli.default_handler = function(...) {})
+  local_mocked_bindings(interactive = function(...) FALSE)
+  library(ellmer)
+
+  simple_addition <- tibble::tibble(
+    input = c("What's 2+2?", "What's 2+3?"),
+    target = c("4", "5")
+  )
+
+  solver_no_dots <- function(inputs, solver_param = "default") {
+    list(
+      result = c("4", "5"),
+      solver_chat = list(
+        chat_openai(model = "gpt-4.1-nano"),
+        chat_openai(model = "gpt-4.1-nano")
+      )
+    )
+  }
+
+  scorer_no_dots <- function(samples, scorer_param = "default") {
+    list(score = c(1, 1))
+  }
+
+  tsk <- Task$new(
+    dataset = simple_addition,
+    solver = solver_no_dots,
+    scorer = scorer_no_dots
+  )
+
+  expect_snapshot(tsk$eval(unmatched_param = "error"), error = TRUE)
+})

--- a/tests/testthat/test-task.R
+++ b/tests/testthat/test-task.R
@@ -2,8 +2,7 @@ test_that("Task R6 class works", {
   skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   tmp_dir <- withr::local_tempdir()
   withr::local_envvar(list(VITALS_LOG_DIR = tmp_dir))
-  withr::local_options(cli.default_handler = function(...) {
-  })
+  withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
   library(ellmer)
 
@@ -52,8 +51,7 @@ test_that("Task with epochs works", {
   skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   tmp_dir <- withr::local_tempdir()
   withr::local_envvar(list(VITALS_LOG_DIR = tmp_dir))
-  withr::local_options(cli.default_handler = function(...) {
-  })
+  withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
 
   library(ellmer)
@@ -95,8 +93,7 @@ test_that("Task respects `$new(epochs)`", {
   skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   tmp_dir <- withr::local_tempdir()
   withr::local_envvar(list(VITALS_LOG_DIR = tmp_dir))
-  withr::local_options(cli.default_handler = function(...) {
-  })
+  withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
 
   library(ellmer)
@@ -123,8 +120,7 @@ test_that("`$eval(epochs)` takes precedence over `$new(epochs)`", {
   skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   tmp_dir <- withr::local_tempdir()
   withr::local_envvar(list(VITALS_LOG_DIR = tmp_dir))
-  withr::local_options(cli.default_handler = function(...) {
-  })
+  withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
 
   library(ellmer)
@@ -151,30 +147,24 @@ test_that("check_dataset works", {
   expect_snapshot(
     Task$new(
       dataset = data.frame(input = 1),
-      solver = function() {
-      },
-      scorer = function() {
-      }
+      solver = function() {},
+      scorer = function() {}
     ),
     error = TRUE
   )
   expect_snapshot(
     Task$new(
       dataset = data.frame(target = 1),
-      solver = function() {
-      },
-      scorer = function() {
-      }
+      solver = function() {},
+      scorer = function() {}
     ),
     error = TRUE
   )
   expect_snapshot(
     Task$new(
       dataset = data.frame(x = 1),
-      solver = function() {
-      },
-      scorer = function() {
-      }
+      solver = function() {},
+      scorer = function() {}
     ),
     error = TRUE
   )
@@ -223,10 +213,8 @@ test_that("Task preserves existing id column", {
 
   tsk <- Task$new(
     dataset = d,
-    solver = function() {
-    },
-    scorer = function() {
-    }
+    solver = function() {},
+    scorer = function() {}
   )
 
   expect_equal(tsk$get_samples()$id, c(10, 20))
@@ -244,10 +232,8 @@ test_that("Task errors informatively with duplicate ids", {
   expect_snapshot(
     Task$new(
       dataset = d,
-      solver = function() {
-      },
-      scorer = function() {
-      }
+      solver = function() {},
+      scorer = function() {}
     ),
     error = TRUE
   )
@@ -258,8 +244,7 @@ test_that("set_solver works", {
   skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   tmp_dir <- withr::local_tempdir()
   withr::local_envvar(list(VITALS_LOG_DIR = tmp_dir))
-  withr::local_options(cli.default_handler = function(...) {
-  })
+  withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
 
   simple_addition <- tibble::tibble(
@@ -270,10 +255,8 @@ test_that("set_solver works", {
 
   tsk <- Task$new(
     dataset = simple_addition,
-    solver = function() {
-    },
-    scorer = function() {
-    }
+    solver = function() {},
+    scorer = function() {}
   )
 
   new_solver <- function(inputs) {
@@ -315,8 +298,7 @@ test_that("set_solver works", {
   skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   tmp_dir <- withr::local_tempdir()
   withr::local_envvar(list(VITALS_LOG_DIR = tmp_dir))
-  withr::local_options(cli.default_handler = function(...) {
-  })
+  withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
 
   simple_addition <- tibble::tibble(
@@ -327,10 +309,8 @@ test_that("set_solver works", {
 
   tsk <- Task$new(
     dataset = simple_addition,
-    solver = function() {
-    },
-    scorer = function() {
-    }
+    solver = function() {},
+    scorer = function() {}
   )
 
   new_solver <- function(inputs) {
@@ -373,8 +353,7 @@ test_that("set_scorer works", {
   skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   tmp_dir <- withr::local_tempdir()
   withr::local_envvar(list(VITALS_LOG_DIR = tmp_dir))
-  withr::local_options(cli.default_handler = function(...) {
-  })
+  withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
 
   simple_addition <- tibble::tibble(
@@ -396,8 +375,7 @@ test_that("set_scorer works", {
   tsk <- Task$new(
     dataset = simple_addition,
     solver = solver,
-    scorer = function() {
-    }
+    scorer = function() {}
   )
 
   tsk$solve()
@@ -456,8 +434,7 @@ test_that("default metrics are applied effectively", {
   skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   tmp_dir <- withr::local_tempdir()
   withr::local_envvar(list(VITALS_LOG_DIR = tmp_dir))
-  withr::local_options(cli.default_handler = function(...) {
-  })
+  withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
   library(ellmer)
 
@@ -486,8 +463,7 @@ test_that("task applies non-default metrics", {
   skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   tmp_dir <- withr::local_tempdir()
   withr::local_envvar(list(VITALS_LOG_DIR = tmp_dir))
-  withr::local_options(cli.default_handler = function(...) {
-  })
+  withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
   library(ellmer)
 
@@ -528,8 +504,7 @@ test_that("task errors informatively with bad metrics", {
   skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   tmp_dir <- withr::local_tempdir()
   withr::local_envvar(list(VITALS_LOG_DIR = tmp_dir))
-  withr::local_options(cli.default_handler = function(...) {
-  })
+  withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
   library(ellmer)
 
@@ -615,8 +590,7 @@ test_that("Task completeness is tracked and preserved", {
   skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   tmp_dir <- withr::local_tempdir()
   withr::local_envvar(list(VITALS_LOG_DIR = tmp_dir))
-  withr::local_options(cli.default_handler = function(...) {
-  })
+  withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
   library(ellmer)
 
@@ -690,8 +664,7 @@ test_that("Task completeness is tracked and preserved", {
 
 test_that("Task errors informatively with bad solver output", {
   withr::local_envvar(list(VITALS_LOG_DIR = withr::local_tempdir()))
-  withr::local_options(cli.default_handler = function(...) {
-  })
+  withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
 
   simple_addition <- tibble::tibble(
@@ -709,8 +682,7 @@ test_that("Task errors informatively with bad solver output", {
   tsk <- Task$new(
     dataset = simple_addition,
     solver = bad_solver_missing_fields,
-    scorer = function() {
-    }
+    scorer = function() {}
   )
 
   expect_snapshot(tsk$solve(), error = TRUE)
@@ -718,8 +690,7 @@ test_that("Task errors informatively with bad solver output", {
 
 test_that("Task detects non-Chat objects in solver_chat", {
   withr::local_envvar(list(VITALS_LOG_DIR = withr::local_tempdir()))
-  withr::local_options(cli.default_handler = function(...) {
-  })
+  withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
 
   simple_addition <- tibble::tibble(
@@ -737,8 +708,7 @@ test_that("Task detects non-Chat objects in solver_chat", {
   tsk <- Task$new(
     dataset = simple_addition,
     solver = bad_solver_wrong_type,
-    scorer = function() {
-    }
+    scorer = function() {}
   )
 
   expect_snapshot(tsk$solve(), error = TRUE)
@@ -747,8 +717,7 @@ test_that("Task detects non-Chat objects in solver_chat", {
 test_that("Task errors informatively with bad scorer output", {
   skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   withr::local_envvar(list(VITALS_LOG_DIR = withr::local_tempdir()))
-  withr::local_options(cli.default_handler = function(...) {
-  })
+  withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
   library(ellmer)
 
@@ -771,8 +740,7 @@ test_that("Task errors informatively with bad scorer output", {
 test_that("Task detects non-Chat objects in scorer_chat", {
   skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   withr::local_envvar(list(VITALS_LOG_DIR = withr::local_tempdir()))
-  withr::local_options(cli.default_handler = function(...) {
-  })
+  withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
   library(ellmer)
 
@@ -798,8 +766,7 @@ test_that("Task detects non-Chat objects in scorer_chat", {
 test_that("token usage is logged correctly", {
   skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   withr::local_envvar(list(VITALS_LOG_DIR = withr::local_tempdir()))
-  withr::local_options(cli.default_handler = function(...) {
-  })
+  withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
   library(ellmer)
 
@@ -857,8 +824,7 @@ test_that("token usage is logged correctly (with unrelated token usage)", {
   skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   skip_if(identical(Sys.getenv("ANTHROPIC_API_KEY"), ""))
   withr::local_envvar(list(VITALS_LOG_DIR = withr::local_tempdir()))
-  withr::local_options(cli.default_handler = function(...) {
-  })
+  withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
   library(ellmer)
 
@@ -896,6 +862,7 @@ test_that("token usage is logged correctly (with unrelated token usage)", {
 
 # argument routing --------------------------------------------------------
 test_that("eval routes arguments correctly to solver and scorer", {
+  skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   withr::local_envvar(list(VITALS_LOG_DIR = withr::local_tempdir()))
   withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
@@ -938,6 +905,7 @@ test_that("eval routes arguments correctly to solver and scorer", {
 })
 
 test_that("eval routes arguments to functions with ellipses", {
+  skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   withr::local_envvar(list(VITALS_LOG_DIR = withr::local_tempdir()))
   withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
@@ -982,6 +950,7 @@ test_that("eval routes arguments to functions with ellipses", {
 })
 
 test_that("eval routes unmatched arguments to solver with ellipses only", {
+  skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   withr::local_envvar(list(VITALS_LOG_DIR = withr::local_tempdir()))
   withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)
@@ -1045,6 +1014,7 @@ test_that("eval errors with unnamed arguments", {
 })
 
 test_that("eval errors when argument matches neither function and neither has ellipses", {
+  skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   withr::local_envvar(list(VITALS_LOG_DIR = withr::local_tempdir()))
   withr::local_options(cli.default_handler = function(...) {})
   local_mocked_bindings(interactive = function(...) FALSE)

--- a/tests/testthat/test-task.R
+++ b/tests/testthat/test-task.R
@@ -876,14 +876,14 @@ test_that("eval routes arguments correctly to solver and scorer", {
   solver_arg_tracker <- NULL
   scorer_arg_tracker <- NULL
 
+  ch <- chat_openai(model = "gpt-4.1-nano")
+  ch$chat("Hey!", echo = FALSE)
+
   custom_solver <- function(inputs, solver_param = "default_solver") {
     solver_arg_tracker <<- solver_param
     list(
       result = c("4", "5"),
-      solver_chat = list(
-        chat_openai(model = "gpt-4.1-nano"),
-        chat_openai(model = "gpt-4.1-nano")
-      )
+      solver_chat = list(ch, ch)
     )
   }
 
@@ -919,15 +919,15 @@ test_that("eval routes arguments to functions with ellipses", {
   solver_dots_tracker <- NULL
   scorer_dots_tracker <- NULL
 
+  ch <- chat_openai(model = "gpt-4.1-nano")
+  ch$chat("Hey!", echo = FALSE)
+
   solver_with_dots <- function(inputs, ...) {
     dots <- list(...)
     solver_dots_tracker <<- dots
     list(
       result = c("4", "5"),
-      solver_chat = list(
-        chat_openai(model = "gpt-4.1-nano"),
-        chat_openai(model = "gpt-4.1-nano")
-      )
+      solver_chat = list(ch, ch)
     )
   }
 
@@ -963,15 +963,15 @@ test_that("eval routes unmatched arguments to solver with ellipses only", {
 
   solver_dots_tracker <- NULL
 
+  ch <- chat_openai(model = "gpt-4.1-nano")
+  ch$chat("Hey!", echo = FALSE)
+
   solver_with_dots <- function(inputs, ...) {
     dots <- list(...)
     solver_dots_tracker <<- dots
     list(
       result = c("4", "5"),
-      solver_chat = list(
-        chat_openai(model = "gpt-4.1-nano"),
-        chat_openai(model = "gpt-4.1-nano")
-      )
+      solver_chat = list(ch, ch)
     )
   }
 
@@ -1025,13 +1025,13 @@ test_that("eval errors when argument matches neither function and neither has el
     target = c("4", "5")
   )
 
+  ch <- chat_openai(model = "gpt-4.1-nano")
+  ch$chat("Hey!", echo = FALSE)
+
   solver_no_dots <- function(inputs, solver_param = "default") {
     list(
       result = c("4", "5"),
-      solver_chat = list(
-        chat_openai(model = "gpt-4.1-nano"),
-        chat_openai(model = "gpt-4.1-nano")
-      )
+      solver_chat = list(ch, ch)
     )
   }
 


### PR DESCRIPTION
Closes #152.

`$eval()` now routes arguments to solvers and scorers based on their function signatures, allowing users to pass arguments specific to each without requiring ellipses in both functions. `$eval()` now errors when supplied unnamed arguments.

As for `detect_match()`, this means that the code from the issue "just works" now; `solver_chat` will be routed to the solver and ignored by the scorer.

```r
simple_addition <- tibble(
  input = c("What's 2+2?", "What's 2+3?"),
  target = c("4", "5")
)

tsk <-
  Task$new(
  dataset = simple_addition,
  solver = generate(),
  scorer = detect_match()
)

tsk$eval(solver_chat = chat_anthropic(model = "claude-sonnet-4-20250514"))
#> ✔ Solving [2.3s]                      
#> ✔ Scoring [25ms]
#> ✔ Inspect Viewer running at: <http://127.0.0.1:7576>
```

For a bit, I explored wrapping the solver and scorer functions themselves to just ignore those arguments, but working around the `logged()` machinery was a hoot and a half.